### PR TITLE
Fixed broken start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ yarn start  # selects 'yarn dev' or 'yarn prod' based
 To launch on a server with [PM2](http://pm2.keymetrics.io) installed globally,
 run with `yarn pm2` or `npm run pm2`. This will allow you to monitor the status
 of the server, and auto-restart it if it crashes.
-**PM2 must have Typescript installed: `pm2 install typescript`.**
 
 #### Using auto-deployment:
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "express-starter",
   "version": "1.5.0",
   "description": "An opinionated Typescript starter setup for Express + Pino.",
-  "homepage": "https://github.com/steven-xie/express-starter",
-  "repository": "github:steven-xie/express-starter",
+  "repository": "https://github.com/steven-xie/express-starter",
   "bugs": {
     "url": "https://github.com/steven-xie/express-starter/issues",
     "email": "dev@stevenxie.me"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-starter",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "An opinionated Typescript starter setup for Express + Pino.",
   "repository": "https://github.com/steven-xie/express-starter",
   "bugs": {
@@ -14,14 +14,14 @@
     "prod-log-level": "error",
     "jmespath-log-filter": "contains(name, `server`)",
     "browser-live-reload": false,
-    "docker-build-env": "development",
-    "docker-tag": "1.2.0-dev",
+    "docker-build-env": "production",
+    "docker-tag": "1.2.1-prod",
     "docker-node-version": "10.4.0"
   },
   "scripts": {
     "dev": "./scripts/dev.sh",
     "prod": "./scripts/prod.sh",
-    "start": "[ '$NODE_ENV' == production ] && npm run prod || npm run dev",
+    "start": "[ \"$NODE_ENV\" == production ] && npm run prod || npm run dev",
     "build": "[ -d build ] && npm run clean; npm run compile",
     "compile": "tsc --project tsconfig.json",
     "compile-watch": "npm run compile -- --watch",


### PR DESCRIPTION
Updated `README.md` and `package.json` with more accurate information, and switched to double quotes in the `yarn start` script to fix the Bash boolean-check.