### PR TITLE
Development source mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ npm install
 <br />
 
 
-## General Usage
+## General usage
 
-### Starting the Server:
+### Starting the server:
 
 ```bash
 # If using Yarn:
@@ -35,9 +35,12 @@ yarn start  # selects 'yarn dev' or 'yarn prod' based
 #   'npm run ...' for each command.
 ```
 
-### Default Endpoints:
+### Default endpoints:
 
 * `/` - Endpoint for `static/index.html`. Static assets are served from `static/`.
+
+  > *Note that in production, usage of Express as a static asset server is discouraged, as it is much more efficient to use NGINX to serve static content, and to use Express only as an API server.*
+
 * `/api` - Main API endpoint; returns a `text/plain` message indicating that the
   API is working.
 * `/api/puppies` - Sample API endpoint that counts page refreshes. Sends data
@@ -47,7 +50,7 @@ yarn start  # selects 'yarn dev' or 'yarn prod' based
 <br />
 
 
-## Docker Usage
+## Usage with Docker
 
 ### Setup
 
@@ -77,7 +80,9 @@ yarn dk-build-dev
 Once you build a version, the `.env` file will be populated with the build
 configuration (i.e. BUILD_ENV and BUILD_TAG). 
 
-_**Method 2:** Pulling an image from Docker Hub:_
+_**Method 2:** Pulling a remote registry image._
+
+Pull the latest image from Docker Hub:
 
 ```bash
 docker pull stevenxie/express-starter
@@ -97,7 +102,7 @@ yarn dk-foreground
 yarn dk-up
 ```
 
-### Regular usage
+### Normal usage
 
 To stop the container, run `yarn dk-stop`, and to run it again, run
 `yarn dk-start`. The container can also be paused with `yarn dk-pause`.
@@ -128,7 +133,7 @@ cd /var/lib/docker/volumes
 <br />
 
 
-## PM2 Usage:
+## Usage with PM2 
 
 To launch on a server with [PM2](http://pm2.keymetrics.io) installed globally,
 run with `yarn pm2` or `npm run pm2`. This will allow you to monitor the status

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ yarn prod   # starts a production server with minimal
 yarn start  # selects 'yarn dev' or 'yarn prod' based
             # on your NODE_ENV
 
-# If using NPM, replace 'yarn ...' with 
-#   'npm run ...' for each command.
+# If using NPM, replace 'yarn ...' with 'npm run ...'
+#   However, 'yarn' is highly recommended for a more
+#   deterministic package installation!
 ```
 
 ### Default endpoints:
@@ -57,14 +58,14 @@ yarn start  # selects 'yarn dev' or 'yarn prod' based
 _**Method 1:** Building an image from scratch._
 
 First, edit `package.json`'s *config* section:
-* Set `docker-image-version` to a pattern that matches *"#.#.#"* (typically
-  using [semver](https://semver.org) versioning). This affects the tag of the
-  built *docker image* (which will look something along the lines of
-  *#.#.#-prod* or *#.#.#-dev*), and also sets the image "version" label.
+* Set `docker-image-version` to a pattern that matches **#.#.#** (typically
+  using [*semver*](https://semver.org))). This affects the tag of the
+  built **Docker image** (which will look something along the lines of
+  **#.#.#-prod** or **#.#.#-dev**), and also sets the image **version** label.
 
-Now, decide whether you want to build for *production* or *development* (this
-affects the installed dependencies, and whether `express-starter` runs in
-development / production mode), and run the associated command:
+Now, decide whether you want to build for **production** or **development**
+(this affects the installed dependencies, and whether `express-starter` runs
+in development / production mode), and run the associated command:
 
 ```bash
 # dk = docker
@@ -78,7 +79,7 @@ yarn dk-build-dev
 ```
 
 Once you build a version, the `.env` file will be populated with the build
-configuration (i.e. BUILD_ENV and BUILD_TAG). 
+configuration (i.e. `BUILD_ENV` and `BUILD_TAG`). 
 
 _**Method 2:** Pulling a remote registry image._
 
@@ -88,11 +89,12 @@ Pull the latest image from Docker Hub:
 docker pull stevenxie/express-starter
 ```
 
-Then, start a container from Docker Compose (which is named `express-starter`,
-configured to expose port _3000_, and mount a volume named `express-vol`). 
-If no image has been built, it will also build an image before starting a 
-container from it. *Make sure you have Docker Compose installed, or look up
-how to manually configure a built with `docker build`!*
+Then, start a container from [Docker Compose](https://docs.docker.com/compose/)
+(which is named `express-starter`, configured to expose port **3000**, and
+mount a volume named `express-vol`). If no image has been built, it will also
+build an image before starting a container from it. *Make sure you have
+[Docker Compose](https://docs.docker.com/compose/) installed, or look up how
+to manually configure a build with `docker build`!*
 
 ```bash
 # To see output in the console foreground (dk = docker)
@@ -104,19 +106,28 @@ yarn dk-up
 
 ### Normal usage
 
+To instantiate a container, run `yarn dk-up`. If no image is built, it will
+also build the initial image.
+
+> *For more information about Docker images and containers, please see [Docker's  documentation](https://docs.docker.com/v17.09/engine/userguide/storagedriver/imagesandcontainers/).*
+
 To stop the container, run `yarn dk-stop`, and to run it again, run
 `yarn dk-start`. The container can also be paused with `yarn dk-pause`.
 
-To remove the container entirely, run `yarn dk-down`.
+To remove the container entirely, run `yarn dk-down`. To also remove images,
+run `yarn dk-purge`.
 
-If you have multiple environments / tags, you can have the `Yarn dk-...` scripts
+> See the `package.json` for more useful Docker-related scripts! Each Docker 
+> script is prefixed with `dk-`.
+
+If you have multiple environments / tags, you can have the `yarn dk-...` scripts
 target a different image by editing the `.env` file with the correct `BUILD_ENV`
 and `BUILD_TAG`.
 
 ### Accessing Volumes on Mac OS X
 
 If you're on a Mac, you won't be able to access the `express-vol` Docker
-volume directly through the filesystem: You have to access it through
+volume directly through the filesystem; you'll have to access it through
 Docker's VM as follows:
 
 ```bash
@@ -141,10 +152,12 @@ of the server, and auto-restart it if it crashes.
 
 ### Using auto-deployment:
 
-If you have your server settings correctly filled out in `pm2.ecosystem.conf.js → deployment`, and your server has your GitHub SSH keys / credentials, then you can set-up the server instantly as follows:
+If you have your server settings correctly filled out in
+**pm2.ecosystem.conf.js → deployment**, and your server has your GitHub SSH
+keys / credentials, then you can set-up the server instantly as follows:
 
 ```bash
-# If using Yarn:
+# Assuming using Yarn:
 yarn pm2-setup
 yarn pm2-deploy
 ```
@@ -168,14 +181,14 @@ then it is necessary to run `yarn pm2-update-force` instead.
 * `jmespath-log-filter` – the filter to be applied to the console
   output logs during development. Uses the
   [JMESPath query language](http://jmespath.org). To show all output,
-  use: `*`. _(default: `` contains(name, `server`) ``)_
+  set to: `*`. _(default: `` contains(name, `server`) ``)_
 * `browser-live-reload` – whether or not you would like the _browser_ to reload
   when you save your code. Useful if you're making visual changes. (The server
-  itself will always live-reload to reflect new changes). _(default: `true`)_
-* `docker-image-version` — a pattern that matches *"#.#.#"* (typically using
-  [semver](https://semver.org) versioning). This affects the tag of the built
-  *docker image* (which will look something along the lines of *#.#.#-prod*
-  or *#.#.#-dev*), and also sets the image "version" label.
+  itself will always live-reload to reflect new changes). _(default: `false`)_
+* `docker-image-version` — a pattern that matches **#.#.#** (typically using
+  [semver](https://semver.org)). This affects the tag of the built
+  **docker image** (which will look something along the lines of **#.#.#-prod**
+  or **#.#.#-dev**), and also sets the image **version** label.
 
 ### docker-compose.yml
 The '**services → express → environment**' section can be configured with

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-starter",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "An opinionated Typescript starter setup for Express + Pino.",
   "repository": "https://github.com/steven-xie/express-starter",
   "bugs": {
@@ -14,7 +14,7 @@
     "prod-log-level": "error",
     "jmespath-log-filter": "contains(name, `server`)",
     "browser-live-reload": false,
-    "docker-image-version": "1.2.3"
+    "docker-image-version": "1.2.4"
   },
   "scripts": {
     "dev": "./scripts/dev.sh",
@@ -70,6 +70,7 @@
     "pino-pretty": "https://github.com/pinojs/pino-pretty.git#v2.0.0-rc.1",
     "prettier": "^1.13.5",
     "rimraf": "^2.6.2",
+    "source-map-support": "^0.5.6",
     "typescript": "^2.9.1"
   }
 }

--- a/src/routes/APIRouter.ts
+++ b/src/routes/APIRouter.ts
@@ -11,8 +11,8 @@ export class APIRouter extends CustomRouter {
   }
 
   registerRoutes() {
-    this.router.get('/', (_, res) => res.json('The API is working!'));
     this.router.use('/puppies', this.puppyRouter);
+    this.router.get('/', (_, res) => res.json('The API is working!'));
   }
 }
 

--- a/src/routes/puppies/PuppyRouter.ts
+++ b/src/routes/puppies/PuppyRouter.ts
@@ -17,7 +17,13 @@ class PuppyRouter extends CustomRouter {
     this.router.get('/', this.getPuppies);
   }
 
-  getPuppies(req: Request, res: Response) {
+  /**
+   * Returns an `application/json` response that reflects the current
+   *   state of the program.
+   * Is an arrow function in order to capture `this` in its closure, so that
+   *   it would register correctly in `registerRoutes`.
+   */
+  getPuppies = (req: Request, res: Response) => {
     this.hitCount += 1;
     const resObj = {
       messages: 'Puppies API was hit!',
@@ -30,7 +36,7 @@ class PuppyRouter extends CustomRouter {
     logger.info(resObj);
     // Send to client as prettified JSON
     sendPrettyJSON(res, resObj);
-  }
+  };
 }
 
 export default PuppyRouter;

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,13 +2,17 @@ import * as dotenv from 'dotenv';
 import { Application } from 'express';
 import * as _getPort from 'get-port';
 import * as http from 'http';
+import { install as installSourceMaps } from 'source-map-support';
 import opn = require('opn');
 
 import App from './App';
 import { serverLogger as logger } from './imports';
 type ErrnoException = NodeJS.ErrnoException;
 
-dotenv.load(); // Load .env variables
+// Make V8 refer back to Typescript code when outputting messages
+if (process.env.NODE_ENV === 'development') installSourceMaps();
+// Load .env variables upon entry, if available.
+dotenv.load();
 
 const app = new App().export(); // Start application
 start(app);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "outDir": "build",
     "strict": true,
     "allowJs": false,
-    "sourceMap": false,
+    "sourceMap": true,
     "inlineSources": false,
     "removeComments": true,
     "noImplicitAny": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -248,6 +248,10 @@ braces@^2.3.0, braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
+buffer-from@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
@@ -1825,6 +1829,13 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
@@ -1832,6 +1843,10 @@ source-map-url@^0.4.0:
 source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spawn-command@^0.0.2-1:
   version "0.0.2-1"


### PR DESCRIPTION
Now, when you get errors in Express during development, the stack trace will point back to lines in your original Typescript source, rather than the compiled Javascript. 🌮 